### PR TITLE
Have the teardown delete current conf, not the e-mission conf!

### DIFF
--- a/percom_moves_collect_2014/setup.sh
+++ b/percom_moves_collect_2014/setup.sh
@@ -1,0 +1,1 @@
+source ../setup.sh

--- a/percom_moves_collect_2014/teardown.sh
+++ b/percom_moves_collect_2014/teardown.sh
@@ -1,0 +1,1 @@
+source ../teardown.sh

--- a/teardown.sh
+++ b/teardown.sh
@@ -1,2 +1,2 @@
 source deactivate emission
-rm -r $EMISSION_SERVER_HOME/conf
+rm -r ./conf


### PR DESCRIPTION
Also, since we are sourcing the base setup/teardown, they already operate in
the current directory.

No need for additional copy/remove